### PR TITLE
Use attribute (rather than child) for property value

### DIFF
--- a/carrot-osgi-anno-scr/carrot-osgi-anno-scr-make/src/main/java/com/carrotgarden/osgi/anno/scr/conv/PropertyBeanConverter.java
+++ b/carrot-osgi-anno-scr/carrot-osgi-anno-scr-make/src/main/java/com/carrotgarden/osgi/anno/scr/conv/PropertyBeanConverter.java
@@ -34,7 +34,7 @@ public class PropertyBeanConverter implements Converter {
 
 		writer.addAttribute("name", bean.name);
 		writer.addAttribute("type", bean.type);
-		writer.setValue(bean.value);
+		writer.addAttribute("value", bean.value);
 
 	}
 
@@ -46,7 +46,7 @@ public class PropertyBeanConverter implements Converter {
 
 		bean.name = reader.getAttribute("name");
 		bean.type = reader.getAttribute("type");
-		bean.value = reader.getValue();
+		bean.value = reader.getAttribute("value");
 
 		return bean;
 

--- a/carrot-osgi-anno-scr/carrot-osgi-anno-scr-make/src/test/java/com/carrotgarden/osgi/anno/scr/case02/Comp_02_1.xml
+++ b/carrot-osgi-anno-scr/carrot-osgi-anno-scr-make/src/test/java/com/carrotgarden/osgi/anno/scr/case02/Comp_02_1.xml
@@ -6,14 +6,14 @@
       <provide interface="java.lang.Runnable"/>
       <provide interface="java.util.concurrent.Future"/>
     </service>
-    <property name="OVER" type="String">level 1</property>
-    <property name="be" type="String">happy at comp 1</property>
-    <property name="good-bye" type="String">hello property</property>
-    <property name="hello" type="String">hello property</property>
-    <property name="hello-string" type="String">world</property>
-    <property name="override" type="String">level 1</property>
-    <property name="size" type="Integer">100</property>
-    <property name="wrong" type="String">wrong type</property>
+    <property name="OVER" type="String" value="level 1"/>
+    <property name="be" type="String" value="happy at comp 1"/>
+    <property name="good-bye" type="String" value="hello property"/>
+    <property name="hello" type="String" value="hello property"/>
+    <property name="hello-string" type="String" value="world"/>
+    <property name="override" type="String" value="level 1"/>
+    <property name="size" type="Integer" value="100"/>
+    <property name="wrong" type="String" value="wrong type"/>
     <properties entry="OSGI-INF/hello.properties"/>
     <properties entry="brand/system.properties"/>
     <reference name="java.lang.CharSequence/*" interface="java.lang.CharSequence" bind="bind" unbind="unbind"/>

--- a/carrot-osgi-anno-scr/carrot-osgi-anno-scr-make/src/test/java/com/carrotgarden/osgi/anno/scr/case02/Comp_02_2.xml
+++ b/carrot-osgi-anno-scr/carrot-osgi-anno-scr-make/src/test/java/com/carrotgarden/osgi/anno/scr/case02/Comp_02_2.xml
@@ -5,15 +5,15 @@
       <provide interface="java.lang.Comparable"/>
       <provide interface="java.util.concurrent.Callable"/>
     </service>
-    <property name="OVER" type="String">level 2</property>
-    <property name="be" type="String">happy at comp 1</property>
-    <property name="good-bye" type="String">hello property</property>
-    <property name="hello" type="String">hello property</property>
-    <property name="hello-2" type="Float">2.5</property>
-    <property name="hello-string" type="String">world</property>
-    <property name="override" type="String">level 2</property>
-    <property name="size" type="Integer">100</property>
-    <property name="wrong" type="String">wrong type</property>
+    <property name="OVER" type="String" value="level 2"/>
+    <property name="be" type="String" value="happy at comp 1"/>
+    <property name="good-bye" type="String" value="hello property"/>
+    <property name="hello" type="String" value="hello property"/>
+    <property name="hello-2" type="Float" value="2.5"/>
+    <property name="hello-string" type="String" value="world"/>
+    <property name="override" type="String" value="level 2"/>
+    <property name="size" type="Integer" value="100"/>
+    <property name="wrong" type="String" value="wrong type"/>
     <properties entry="OSGI-INF/hello.properties"/>
     <properties entry="brand/system.properties"/>
     <reference name="java.lang.CharSequence/*" interface="java.lang.CharSequence" bind="bind" unbind="unbind"/>

--- a/carrot-osgi-anno-scr/carrot-osgi-anno-scr-make/src/test/java/com/carrotgarden/osgi/anno/scr/case03/Comp_03_1_props.xml
+++ b/carrot-osgi-anno-scr/carrot-osgi-anno-scr-make/src/test/java/com/carrotgarden/osgi/anno/scr/case03/Comp_03_1_props.xml
@@ -1,14 +1,14 @@
 <container xmlns="http://www.osgi.org/xmlns/scr/v1.1.0">
   <component name="com.carrotgarden.osgi.anno.scr.case03.Comp_03_1_props">
     <implementation class="com.carrotgarden.osgi.anno.scr.case03.Comp_03_1_props"/>
-    <property name="BOOL" type="Boolean">true</property>
-    <property name="BYTE" type="Byte">-1</property>
-    <property name="CHAR" type="Character">A</property>
-    <property name="DOUBLE" type="Double">-1.0</property>
-    <property name="FLOAT" type="Float">-1.0</property>
-    <property name="INTEGER" type="Integer">3</property>
-    <property name="LONG" type="Long">123</property>
-    <property name="SHORT" type="Short">-1024</property>
-    <property name="STRING" type="String">string</property>
+    <property name="BOOL" type="Boolean" value="true"/>
+    <property name="BYTE" type="Byte" value="-1"/>
+    <property name="CHAR" type="Character" value="A"/>
+    <property name="DOUBLE" type="Double" value="-1.0"/>
+    <property name="FLOAT" type="Float" value="-1.0"/>
+    <property name="INTEGER" type="Integer" value="3"/>
+    <property name="LONG" type="Long" value="123"/>
+    <property name="SHORT" type="Short" value="-1024"/>
+    <property name="STRING" type="String" value="string"/>
   </component>
 </container>


### PR DESCRIPTION
Prior to this commit, when writing out the properties
for a service component descriptor xml, the property
values were written as an XML child element inside
of the `property` tag.

In some OSGi implementations (Felix, at least), this
causes the service property to be initialized as
an array of String objects, rather than a single
instance of String.  Many existing OSGi services
that interrogate these properties seem to be
written to expect a String instance, rather than
an array of Strings; thus, these services fail
or cannot determine the values of the properties.

This commit simply changes the XML writer to
write the property values as a `value` attribute
on the `property` tag, rather than as a nested
child element.  (This is the behavior that the
felix-scr plugin provides.)  With this change,
services that were previously failing seem to
succeed.
